### PR TITLE
style: Basalt design system compliance for radius tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -138,6 +138,7 @@
   /* Radii */
   --radius-card: 14px;
   --radius-widget: 10px;
+  --radius-island: 20px;
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -95,7 +95,7 @@ function AppShellInner({ children, breadcrumbs = [] }: AppShellProps) {
 
         {/* Floating island content area */}
         <div className="flex-1 px-2 pb-2 md:px-3 md:pb-3">
-          <div className="h-full rounded-[16px] md:rounded-[20px] bg-card p-3 md:p-5 overflow-y-auto">
+          <div className="h-full rounded-[var(--radius-card)] md:rounded-[var(--radius-island)] bg-card p-3 md:p-5 overflow-y-auto">
             {children}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add missing `--radius-island: 20px` CSS variable to design system
- Refactor app-shell to use CSS variables instead of hardcoded values

## Test plan
- [x] Visual inspection of floating island radius
- [x] Verify CSS variable defined in globals.css
- [x] Verify app-shell uses var(--radius-card) and var(--radius-island)

🤖 Generated with [Claude Code](https://claude.com/claude-code)