### PR TITLE
ci: enable L2 API E2E tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,6 @@ jobs:
       test-command: "bun run test:coverage"
       typecheck-command: "bun run typecheck"
       osv-config: "osv-scanner.toml"
-      enable-l2: "false"
+      enable-l2: "true"
+      l2-command: "bun run test:e2e"
     secrets: inherit

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -1,21 +1,42 @@
 /**
  * E2E test runner — runs all E2E test suites.
  *
- * Currently: Worker API E2E tests (requires `wrangler dev` running on :8787).
- * Future: Playwright browser E2E tests.
+ * Targets:
+ *   - Local: a `wrangler dev` server on http://127.0.0.1:8787 (default).
+ *   - CI / remote: set WORKER_URL (and WORKER_SECRET) to point at a
+ *     deployed Worker. In CI we hard-fail if the Worker is unreachable;
+ *     locally we skip with exit 0 (so pre-push hooks stay friendly when
+ *     the dev server isn't running).
  */
 
 import { $ } from "bun";
 
-const isWorkerRunning = await fetch("http://127.0.0.1:8787/api/live")
+const isCI = process.env.CI === "true";
+const envWorkerUrl = process.env.WORKER_URL?.trim();
+
+// In CI, WORKER_URL must be set via repo secrets. If it isn't, skip
+// gracefully (don't fail the build) — matches the project rule that
+// missing secrets should not break CI.
+if (isCI && !envWorkerUrl) {
+  console.warn("WORKER_URL not set in CI — skipping E2E tests");
+  process.exit(0);
+}
+
+const WORKER_URL = envWorkerUrl ?? "http://127.0.0.1:8787";
+
+const isWorkerRunning = await fetch(`${WORKER_URL}/api/live`)
   .then((r) => r.ok)
   .catch(() => false);
 
 if (!isWorkerRunning) {
-  console.error("Worker not running on :8787 — skipping E2E tests");
+  if (isCI) {
+    console.error(`Worker not reachable at ${WORKER_URL} — failing in CI`);
+    process.exit(1);
+  }
+  console.error(`Worker not running at ${WORKER_URL} — skipping E2E tests`);
   process.exit(0);
 }
 
-console.log("Running Worker E2E tests...");
+console.log(`Running Worker E2E tests against ${WORKER_URL}...`);
 const result = await $`bun test --cwd . worker/tests/e2e`.nothrow();
 process.exit(result.exitCode);

--- a/worker/db/migrations/0005_add_is_archived.sql
+++ b/worker/db/migrations/0005_add_is_archived.sql
@@ -1,0 +1,10 @@
+-- Migration: Add is_archived column to financial_products
+-- Note: is_archived was added manually to production before any migration
+-- existed (see 0003 header comment). This migration brings fresh
+-- environments (local dev, CI test DBs) in line with the schema in
+-- worker/db/schema.ts so the column actually exists.
+
+ALTER TABLE financial_products ADD COLUMN is_archived INTEGER DEFAULT 0;
+
+-- Backfill: treat any pre-existing rows as not archived.
+UPDATE financial_products SET is_archived = 0 WHERE is_archived IS NULL;

--- a/worker/tests/e2e/helpers/client.ts
+++ b/worker/tests/e2e/helpers/client.ts
@@ -1,12 +1,16 @@
 /**
  * E2E test client factory.
  *
- * Creates a WorkerDbClient pointed at the local wrangler dev server
- * with `targetDb: "test"` so all queries go to the remote test D1.
+ * Defaults to a local `wrangler dev` server with `targetDb: "test"` so all
+ * queries go to the local test D1 binding. In CI (or any environment that
+ * targets an already-deployed Worker), set `WORKER_URL` and `WORKER_SECRET`
+ * to override.
  */
 
-const WORKER_BASE_URL = "http://127.0.0.1:8787";
+const WORKER_BASE_URL =
+  process.env.WORKER_URL ?? "http://127.0.0.1:8787";
 const WORKER_SECRET =
+  process.env.WORKER_SECRET ??
   "b5edfb5b65dd841904149c2b6e59e7d5977ad8ade330c2768893f81e32bb7605";
 
 // ── Lightweight HTTP helper (no WorkerDbClient dependency) ──
@@ -19,6 +23,11 @@ export interface FetchOptions {
   body?: unknown;
   token?: string;
   omitAuth?: boolean;
+  /**
+   * Override the default fetch redirect behavior. Useful for asserting
+   * 3xx responses directly (e.g. /api/health → /api/live).
+   */
+  redirect?: RequestRedirect;
 }
 
 /**
@@ -44,6 +53,9 @@ export async function rawFetch(opts: FetchOptions): Promise<Response> {
   };
   if (opts.body !== undefined) {
     init.body = JSON.stringify(opts.body);
+  }
+  if (opts.redirect !== undefined) {
+    init.redirect = opts.redirect;
   }
 
   return fetch(`${WORKER_BASE_URL}${opts.path}`, init);


### PR DESCRIPTION
Enable L2 integration/API E2E tests in CI pipeline.\n\n- Set enable-l2 to true\n- Configure l2-command\n- Fix test issues for CI compatibility