### PR TITLE
fix(ui): align bg-card usage to B05 luminance spec

### DIFF
--- a/src/app/balance-anchors/balance-anchors-client.tsx
+++ b/src/app/balance-anchors/balance-anchors-client.tsx
@@ -197,7 +197,7 @@ export function BalanceAnchorsClient({
                     {acctAnchors.map((anchor) => (
                       <div
                         key={`${anchor.accountName}-${anchor.date}`}
-                        className="bg-card flex items-center justify-between rounded-lg border p-3"
+                        className="bg-secondary flex items-center justify-between rounded-lg p-3"
                       >
                         <div className="flex flex-1 items-center gap-4">
                           <div className="flex items-center gap-2 text-sm">


### PR DESCRIPTION
Closes #18\n\nReplace misused bg-card (L1) with bg-secondary (L2) for content cards inside the floating island, per Basalt B05 spec.