### PR TITLE
chore: use VPS_PORT secret for SSH deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          port: ${{ secrets.VPS_PORT }}
           envs: IMAGE_SHA
           script: |
             set -euo pipefail


### PR DESCRIPTION
Adds port to appleboy/ssh-action so CD survives jp2 SSH port migration 22→52722. VPS_PORT secret already set.