### PR TITLE
ci(release): fall back to SSH port 52722 when VPS_PORT secret is unset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          port: ${{ secrets.VPS_PORT }}
+          port: ${{ secrets.VPS_PORT || '52722' }}
           envs: IMAGE_SHA
           script: |
             set -euo pipefail

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ README.md
 - **Edge**: Cloudflare in front of an origin VPS (jp2.nocoo.cloud, Azure 日本). A shared `proxy-caddy` at `/opt/proxy/` terminates TLS with a Cloudflare Origin Certificate (`*.hexly.ai`) and enforces **Authenticated Origin Pulls (mTLS)**, so direct-to-IP traffic is rejected. App containers (`noheir-app`, `neo-app`, …) join the shared docker network `edge`; Caddy reverse-proxies to them by container name.
 - **CI/CD**: `.github/workflows/ci.yml` runs lint + unit tests on every push/PR. `.github/workflows/release.yml` is chained via `workflow_run` — on green CI for `main` it builds & pushes the image, then SSHes into the VPS to `docker compose pull && up -d --no-deps app`, runs an in-container health check, and finally smoke-tests via the public URL. Only the app container rolls; `proxy-caddy` is never touched by app deploys.
 - **Runtime env vars** (injected by the host's `.env`, never baked into the image): `WORKER_URL`, `WORKER_TOKEN`, `AUTH_SECRET`, `NEXTAUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `ALLOWED_EMAILS`.
-- **GitHub Actions secrets** required by `release.yml`: `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`, `GHCR_PULL_USER`, `GHCR_PULL_TOKEN` (PAT with `read:packages`). Host-side compose file references the same image tag.
+- **GitHub Actions secrets** required by `release.yml`: `VPS_HOST`, `VPS_USER`, `VPS_PORT` (SSH port; workflow falls back to `52722` if unset), `VPS_SSH_KEY`, `GHCR_PULL_USER`, `GHCR_PULL_TOKEN` (PAT with `read:packages`). Host-side compose file references the same image tag.
 - See [docs/04-run.md](./docs/04-run.md) for the full deploy guide.
 
 ## Backend (Cloudflare Worker + D1)

--- a/docs/04-run.md
+++ b/docs/04-run.md
@@ -85,7 +85,7 @@ docker run --rm -p 7004:7004 --env-file .env.local noheir:local
    - `.env`（chmod 600）：上表中的所有运行时变量
 4. 共享 docker network：`docker network create edge`（一次性，由 proxy 和所有 app 共用）
 5. SSH 公钥：单独生成一对部署密钥（每个项目一对），公钥放进 `~/.ssh/authorized_keys`，私钥配进 GitHub Actions secret
-6. 防火墙：仅放行 22（部署用，可按需收紧到 GitHub Actions IP 段或临时开启）、80、443
+6. 防火墙：仅放行 52722（部署用，可按需收紧到 GitHub Actions IP 段或临时开启）、80、443
 
 ### CI / CD
 
@@ -113,6 +113,7 @@ Release 步骤要点：
 |------|------|
 | `VPS_HOST` | 源站 hostname / IP |
 | `VPS_USER` | SSH 用户 |
+| `VPS_PORT` | SSH 端口（当前为 `52722`；secret 未配置时 workflow 会兜底使用 `52722`） |
 | `VPS_SSH_KEY` | 部署私钥 |
 | `GHCR_PULL_USER` | GHCR 拉取账号 |
 | `GHCR_PULL_TOKEN` | PAT（classic，scope `read:packages`） |


### PR DESCRIPTION
## Summary
- Recent Release runs (commits 62d98b7, 4b72d40) timed out at `appleboy/ssh-action` with `dial tcp <vps>:<port>: i/o timeout`. Root cause: `secrets.VPS_PORT` resolved to empty, so the action defaulted to port 22 — which is now closed on jp2 (SSH moved to 52722).
- Add an inline fallback `${{ secrets.VPS_PORT || '52722' }}` so the deploy survives the secret being unset or empty.
- Document `VPS_PORT` in the release secrets table (`docs/04-run.md`, `CLAUDE.md`) and update the firewall guidance from port 22 to 52722.

## Test plan
- [ ] Merge to `main` and let the chained `workflow_run` Release job run; confirm the SSH step connects on 52722 and the deploy + smoke-test pass.
- [ ] (Optional) Set the `VPS_PORT` repo/environment secret to `52722` so future port rotations only require flipping the secret without code changes.