### PR TITLE
chore(security): adopt base-ci v2026.2 ignore-scripts (Shai-Hulud defense)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ on:
 
 jobs:
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.1
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.2
     with:
+      ignore-scripts: true
       pre-command: "bun run build"
       test-command: "bun run test:coverage"
       typecheck-command: "bun run typecheck"

--- a/bun.lock
+++ b/bun.lock
@@ -52,8 +52,10 @@
     },
   },
   "trustedDependencies": [
+    "@tailwindcss/oxide",
     "esbuild",
     "sharp",
+    "next",
     "unrs-resolver",
   ],
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
   "trustedDependencies": [
     "esbuild",
     "sharp",
-    "unrs-resolver"
+    "unrs-resolver",
+    "@tailwindcss/oxide",
+    "next"
   ],
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
## Summary

Wave 2 of the Shai-Hulud worm defense rollout: pin the reusable CI workflow to a hardened release and have all `bun install` steps run with `--ignore-scripts`.

## Changes

- `.github/workflows/ci.yml`: bump `nocoo/base-ci/.github/workflows/bun-quality.yml` from `@v2026.1` → `@v2026.2`, set `ignore-scripts: true`.
- `package.json` / `bun.lock`: extend `trustedDependencies` so legitimate native binaries still install under `--ignore-scripts`. Final list:
  - `esbuild`
  - `sharp`
  - `unrs-resolver`
  - `@tailwindcss/oxide`
  - `next`

## Test plan

Verified locally with a clean install:

```
rm -rf node_modules
bun install --ignore-scripts
bun run typecheck   # ok
bun run lint        # ok
bun run build       # ok (full Next.js build)
```

CI on this PR should be the green source of truth.