### PR TITLE
chore(deps): hono ^4.12.23 → 4.12.24 (security, root + worker)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "echarts": "^6.1.0",
         "echarts-for-react": "^3.0.6",
         "esbuild": "^0.28.0",
-        "hono": "^4.12.23",
+        "hono": "^4.12.24",
         "lucide-react": "^1.17.0",
         "next": "16.2.7",
         "next-auth": "^5.0.0-beta.30",
@@ -65,7 +65,7 @@
   "overrides": {
     "@hono/node-server": "1.19.13",
     "fast-uri": "3.1.2",
-    "hono": "4.12.23",
+    "hono": "4.12.24",
     "ip-address": "10.2.0",
     "postcss": "8.5.15",
     "qs": "6.15.2",
@@ -1060,7 +1060,7 @@
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
-    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+    "hono": ["hono@4.12.24", "", {}, "sha512-I36D1s+HgQc55KbhEr4iybfxv/9o1zdpw+XEM6dJa91LqQD0HCoSGdxpRJCZE+aavs87j4V3Ls2OJzq8C/U4iw=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.6",
     "esbuild": "^0.28.0",
-    "hono": "^4.12.23",
+    "hono": "^4.12.24",
     "lucide-react": "^1.17.0",
     "next": "16.2.7",
     "next-auth": "^5.0.0-beta.30",
@@ -87,7 +87,7 @@
   "overrides": {
     "@hono/node-server": "1.19.13",
     "fast-uri": "3.1.2",
-    "hono": "4.12.23",
+    "hono": "4.12.24",
     "ip-address": "10.2.0",
     "postcss": "8.5.15",
     "qs": "6.15.2",

--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -21,6 +21,9 @@
       },
     },
   },
+  "overrides": {
+    "hono": "4.12.24",
+  },
   "packages": {
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
@@ -627,8 +630,6 @@
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
-
-    "@modelcontextprotocol/sdk/hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -25,5 +25,8 @@
     "better-sqlite3": "^12.10.0",
     "vitest": "^4.1.8",
     "wrangler": "^4.98.0"
+  },
+  "overrides": {
+    "hono": "4.12.24"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `hono` to `4.12.24` across both workspaces to clear the security advisories tracked in #62.
- Root `package.json` / `bun.lock`: dependency range `^4.12.23 → ^4.12.24`, `overrides.hono` pin `4.12.23 → 4.12.24`.
- `worker/package.json`: adds a worker-level `overrides.hono = "4.12.24"` so the nested `@modelcontextprotocol/sdk → hono` resolution in `worker/bun.lock` is forced off the previously locked `4.12.9` (the root override does not propagate into the worker's separate Bun project).

Fixes #62.

## Test plan

- [x] `node_modules/hono/package.json` resolves to `4.12.24` in both the root and `worker/`.
- [x] `rg 'hono@4\.12\.(9|23)' bun.lock worker/bun.lock` returns no matches; lockfiles contain a single `hono@4.12.24` entry each.
- [x] `bun run typecheck` ✅
- [x] `bun run worker:typecheck` ✅
- [x] `bun run test` → 71 files / 945 tests passed ✅
- [x] `bun run test:worker` → 16 files / 247 tests passed ✅
- [x] `cd worker && bun audit` no longer reports any Hono advisory (covers the full #62 list up through `GHSA-xrhx-7g5j-rcj5`). Remaining non-Hono advisories (`qs`, `@hono/node-server`, `fast-uri`, `ip-address`) come in through `@modelcontextprotocol/sdk` and are out of scope for this PR.