### PR TITLE
fix(overview): show recent transactions for selected year

### DIFF
--- a/src/app/overview-client.tsx
+++ b/src/app/overview-client.tsx
@@ -31,14 +31,9 @@ export function OverviewClient({
   savingsRate,
   targetSavingsRate,
 }: OverviewClientProps) {
-  // Filter to last month's transactions
-  const oneMonthAgo = new Date()
-  oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
-  const oneMonthAgoStr = oneMonthAgo.toISOString().slice(0, 10)
-
-  const recentTransactions = [...transactions]
-    .filter((t) => t.date >= oneMonthAgoStr)
-    .sort((a, b) => b.date.localeCompare(a.date))
+  const recentTransactions = [...transactions].sort((a, b) =>
+    b.date.localeCompare(a.date)
+  )
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary

The overview page's "最近交易记录" table showed `暂无交易记录，请导入数据` even when the stat cards and trend chart above were rendering non-zero data for the same year. Root cause: `src/app/overview-client.tsx` re-filtered the server-fetched recent transactions to only those within the last 30 days of today's wall-clock date — so any non-current year (or a current year with no activity in the last 30 days) was wiped out client-side.

The server already returns the 10 most recent transactions for `selectedYear`, sorted `date DESC, created_at DESC`. Drop the client-side date filter and render what the server returns. Regression came from commit 3d26006 `feat(overview): show last month's transactions instead of top 10`.

Linked issue: [STU-523](https://github.com/nocoo/noheir/issues) — 财务概览页面不加载交易数据问题.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 945 / 945 passed
- [ ] Manual: visit `/` for a year with prior-year-only data and confirm the table renders recent transactions instead of the empty-state message.