### PR TITLE
feat(plan-calendar): replace day dots with informative banners

### DIFF
--- a/src/__tests__/components/plan/plan-calendar.test.tsx
+++ b/src/__tests__/components/plan/plan-calendar.test.tsx
@@ -312,6 +312,104 @@ describe("PlanCalendar interaction (P3-C5)", () => {
   });
 });
 
+describe("PlanCalendar banner display (improvement)", () => {
+  test("banner shows rule name and compact amount", () => {
+    const r = rule({
+      id: "r1",
+      name: "房贷",
+      categoryId: "c1",
+      amountCents: 250000, // ¥2,500
+      dayOfMonth: 10,
+    });
+    render(
+      <PlanCalendar
+        viewMonth="2026-02-01"
+        rules={[r]}
+        categoryMap={catMap([{ id: "c1", name: "房贷", colorToken: "chart-9" }])}
+      />,
+    );
+    const banner = screen.getByTestId("banner-2026-02-10-r1");
+    expect(within(banner).getByText("房贷")).toBeInTheDocument();
+    expect(within(banner).getByText("¥2,500")).toBeInTheDocument();
+  });
+
+  test("banner shows '万' suffix for amounts ≥ 10000 yuan", () => {
+    const r = rule({
+      id: "r1",
+      name: "保险",
+      amountCents: 1234500, // 12,345 yuan → ¥1.2万
+      dayOfMonth: 5,
+    });
+    render(
+      <PlanCalendar
+        viewMonth="2026-02-01"
+        rules={[r]}
+        categoryMap={catMap([])}
+      />,
+    );
+    const banner = screen.getByTestId("banner-2026-02-05-r1");
+    expect(within(banner).getByText("¥1.2万")).toBeInTheDocument();
+  });
+
+  test("clicking a banner calls onOpenRule and does NOT call onSelectDay", async () => {
+    const user = userEvent.setup();
+    const onOpenRule = vi.fn();
+    const onSelectDay = vi.fn();
+    const r = rule({ id: "r1", name: "Netflix", amountCents: 9900, dayOfMonth: 12 });
+    render(
+      <PlanCalendar
+        viewMonth="2026-02-01"
+        rules={[r]}
+        categoryMap={catMap([])}
+        onOpenRule={onOpenRule}
+        onSelectDay={onSelectDay}
+      />,
+    );
+    await user.click(screen.getByTestId("banner-2026-02-12-r1"));
+    expect(onOpenRule).toHaveBeenCalledWith("r1");
+    expect(onSelectDay).not.toHaveBeenCalled();
+  });
+
+  test("clicking the +N overflow opens the day detail (onSelectDay)", async () => {
+    const user = userEvent.setup();
+    const onOpenRule = vi.fn();
+    const onSelectDay = vi.fn();
+    const rules = Array.from({ length: 5 }, (_, i) =>
+      rule({ id: `r${i}`, dayOfMonth: 8 }),
+    );
+    render(
+      <PlanCalendar
+        viewMonth="2026-02-01"
+        rules={rules}
+        categoryMap={catMap([])}
+        onOpenRule={onOpenRule}
+        onSelectDay={onSelectDay}
+      />,
+    );
+    await user.click(screen.getByTestId("overflow-2026-02-08"));
+    expect(onSelectDay).toHaveBeenCalledWith("2026-02-08");
+    expect(onOpenRule).not.toHaveBeenCalled();
+  });
+
+  test("clicking empty area of a day still opens day detail (onSelectDay)", async () => {
+    const user = userEvent.setup();
+    const onSelectDay = vi.fn();
+    render(
+      <PlanCalendar
+        viewMonth="2026-02-01"
+        rules={[]}
+        categoryMap={catMap([])}
+        onSelectDay={onSelectDay}
+      />,
+    );
+    const cells = screen.getAllByRole("gridcell");
+    const feb14 = cells.find((c) => c.getAttribute("data-iso") === "2026-02-14");
+    if (!feb14) throw new Error("missing feb 14");
+    await user.click(feb14);
+    expect(onSelectDay).toHaveBeenCalledWith("2026-02-14");
+  });
+});
+
 describe("PlanCalendar cross-month occurrences (P3-C5)", () => {
   test("monthly rule starting in Jan shows up in February too", () => {
     const r = rule({

--- a/src/__tests__/components/plan/plan-calendar.test.tsx
+++ b/src/__tests__/components/plan/plan-calendar.test.tsx
@@ -200,7 +200,11 @@ describe("PlanCalendar occurrence dots (P3-C5)", () => {
     const feb5 = cells.find((c) => c.getAttribute("data-iso") === "2026-02-05");
     const dot = feb5?.querySelector("[data-rule-id='r1']") as HTMLElement | null;
     expect(dot).not.toBeNull();
-    expect(dot?.style.backgroundColor.length).toBeGreaterThan(0);
+    // Banner uses the category color as a left accent stripe; the
+    // fallback path must still apply a color so the banner doesn't
+    // render with a transparent edge.
+    expect(dot?.style.borderLeftColor.length).toBeGreaterThan(0);
+    expect(dot?.getAttribute("data-color")).toBe("fallback");
   });
 
   test("day with > 3 occurrences shows only 3 dots + '+N' overflow", () => {
@@ -389,6 +393,53 @@ describe("PlanCalendar banner display (improvement)", () => {
     await user.click(screen.getByTestId("overflow-2026-02-08"));
     expect(onSelectDay).toHaveBeenCalledWith("2026-02-08");
     expect(onOpenRule).not.toHaveBeenCalled();
+  });
+
+  test("keyboard-activating a banner calls onOpenRule and NOT onSelectDay", async () => {
+    const user = userEvent.setup();
+    const onOpenRule = vi.fn();
+    const onSelectDay = vi.fn();
+    const r = rule({ id: "r1", name: "Netflix", amountCents: 9900, dayOfMonth: 12 });
+    render(
+      <PlanCalendar
+        viewMonth="2026-02-01"
+        rules={[r]}
+        categoryMap={catMap([])}
+        onOpenRule={onOpenRule}
+        onSelectDay={onSelectDay}
+      />,
+    );
+    const banner = screen.getByTestId("banner-2026-02-12-r1");
+    banner.focus();
+    expect(banner).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(onOpenRule).toHaveBeenCalledWith("r1");
+    expect(onSelectDay).not.toHaveBeenCalled();
+
+    onOpenRule.mockClear();
+    banner.focus();
+    await user.keyboard(" ");
+    expect(onOpenRule).toHaveBeenCalledWith("r1");
+    expect(onSelectDay).not.toHaveBeenCalled();
+  });
+
+  test("keyboard Enter on the cell itself calls onSelectDay", async () => {
+    const user = userEvent.setup();
+    const onSelectDay = vi.fn();
+    render(
+      <PlanCalendar
+        viewMonth="2026-02-01"
+        rules={[]}
+        categoryMap={catMap([])}
+        onSelectDay={onSelectDay}
+      />,
+    );
+    const cells = screen.getAllByRole("gridcell");
+    const feb14 = cells.find((c) => c.getAttribute("data-iso") === "2026-02-14");
+    if (!feb14) throw new Error("missing feb 14");
+    (feb14 as HTMLElement).focus();
+    await user.keyboard("{Enter}");
+    expect(onSelectDay).toHaveBeenCalledWith("2026-02-14");
   });
 
   test("clicking empty area of a day still opens day detail (onSelectDay)", async () => {

--- a/src/__tests__/lib/recurring-expense/format.test.ts
+++ b/src/__tests__/lib/recurring-expense/format.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   deriveDisplayStatus,
   describeFrequency,
+  formatAmountCompact,
   formatAmountYuan,
 } from "@/lib/recurring-expense/format";
 
@@ -160,6 +161,34 @@ describe("formatAmountYuan", () => {
 
   test("very large amounts get thousand-separators", () => {
     expect(formatAmountYuan(123_456_789)).toBe("¥1,234,567.89");
+  });
+});
+
+describe("formatAmountCompact", () => {
+  test("under 10,000 yuan: full integer with separators, no decimals", () => {
+    expect(formatAmountCompact(9900)).toBe("¥99");
+    expect(formatAmountCompact(250_000)).toBe("¥2,500");
+    expect(formatAmountCompact(999_999)).toBe("¥10,000");
+  });
+
+  test("≥ 10,000 yuan: '万' suffix with 1 decimal trimmed of trailing zero", () => {
+    expect(formatAmountCompact(1_000_000)).toBe("¥1万");
+    expect(formatAmountCompact(1_234_500)).toBe("¥1.2万");
+    expect(formatAmountCompact(50_000_000)).toBe("¥50万");
+  });
+
+  test("very large amounts collapse decimals", () => {
+    expect(formatAmountCompact(100_000_000)).toBe("¥100万");
+    expect(formatAmountCompact(1_000_000_000)).toBe("¥1000万");
+  });
+
+  test("zero", () => {
+    expect(formatAmountCompact(0)).toBe("¥0");
+  });
+
+  test("negative amounts get a leading '-'", () => {
+    expect(formatAmountCompact(-9900)).toBe("-¥99");
+    expect(formatAmountCompact(-1_234_500)).toBe("-¥1.2万");
   });
 });
 

--- a/src/app/plan/calendar/calendar-client.tsx
+++ b/src/app/plan/calendar/calendar-client.tsx
@@ -224,6 +224,7 @@ export function CalendarClient({
           todayIso={todayIso}
           selectedDay={selectedDay}
           onSelectDay={(iso) => setSelectedDay(iso)}
+          onOpenRule={(id) => setEditingId(id)}
         />
       </div>
 

--- a/src/components/plan/plan-calendar.tsx
+++ b/src/components/plan/plan-calendar.tsx
@@ -212,6 +212,15 @@ export function PlanCalendar({
               aria-selected={isSelected || undefined}
               onClick={() => onSelectDay?.(cell.iso)}
               onKeyDown={(e) => {
+                // Only treat key events that originated on the cell
+                // itself as the "open day detail" affordance. Enter /
+                // Space on a focused banner (or +N button) must NOT
+                // also fire this handler — otherwise the popover
+                // would open every time a keyboard user activates a
+                // banner. The child buttons' own onClick handlers
+                // already stopPropagation for mouse clicks, but for
+                // keydown the synthetic event still bubbles here.
+                if (e.target !== e.currentTarget) return;
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   onSelectDay?.(cell.iso);
@@ -266,25 +275,31 @@ export function PlanCalendar({
                         title={`${rule.name} · ${formatAmountCompact(rule.amountCents)}`}
                         aria-label={`${rule.name} ${formatAmountCompact(rule.amountCents)}`}
                         style={{
-                          backgroundColor: color,
-                          // Keep the dot data-color contract for tests
-                          // even though we render a full banner now.
+                          // Render the category color as a left accent
+                          // stripe instead of the banner background.
+                          // White-on-chart-N was failing WCAG AA at
+                          // 10px (chart-6 ~ 1.98, chart-20 ~ 2.01 in
+                          // light theme; even worse in dark). The
+                          // neutral muted background + foreground text
+                          // both come from theme tokens and inherit
+                          // the project's verified contrast.
                           borderLeftColor: color,
                         }}
                         className={cn(
-                          "flex w-full items-center justify-between gap-1 rounded-sm px-1.5 py-0.5",
-                          "text-[10px] font-medium text-white leading-tight",
-                          "outline-none ring-offset-background transition-opacity",
-                          "hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring",
-                          // Drop the bright tint for adjacent-month cells
-                          // so the in-month banners stay the focal point.
+                          "flex w-full items-center justify-between gap-1 rounded-sm py-0.5 pl-1.5 pr-1.5",
+                          "border-l-[3px] bg-muted/70 text-foreground",
+                          "text-[10px] font-medium leading-tight",
+                          "outline-none ring-offset-background transition-colors",
+                          "hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring",
+                          // Dim the entire banner on out-of-month cells
+                          // so the in-month entries stay the focal point.
                           !cell.inMonth && "opacity-60",
                         )}
                       >
                         <span className="min-w-0 flex-1 truncate text-left">
                           {rule.name}
                         </span>
-                        <span className="shrink-0 tabular-nums">
+                        <span className="shrink-0 tabular-nums text-muted-foreground">
                           {formatAmountCompact(rule.amountCents)}
                         </span>
                       </button>

--- a/src/components/plan/plan-calendar.tsx
+++ b/src/components/plan/plan-calendar.tsx
@@ -7,24 +7,27 @@
 //   - Render a stable 6-row × 7-col grid for one calendar month.
 //     Always 6 rows so the grid does NOT jump in height when a month
 //     starts on Sunday vs Saturday.
-//   - For each visible day, render up to 3 colored dots representing
-//     today's occurrences of recurring rules; if the day has > 3,
-//     append a "+N" badge so the cell stays compact.
+//   - For each visible day, render up to MAX_BANNERS colored banners
+//     for today's occurrences of recurring rules. Each banner shows
+//     the rule name and a compact amount (e.g. "¥2,500" / "¥1.2万"),
+//     tinted with the category's chart-N token so a glance at the
+//     grid tells the user what kind of expense lands when.
+//   - When a day has more occurrences than fit, surface a "+N 更多"
+//     row that opens the existing DayDetailPopover via onSelectDay.
 //   - Delegate occurrence math to `computeOccurrences` (P2-C2). The
 //     component never reimplements recurrence logic.
-//   - Color dots come from the category palette via `chart-N` tokens
-//     (P3-C1's closed set). If a rule's category is missing or its
-//     colorToken is off-palette, fall back to `--muted-foreground` so
-//     the layout stays consistent.
+//   - Colors come from the category palette via `chart-N` tokens
+//     (P3-C1's closed set). Off-palette / missing categories fall
+//     back to a muted neutral so the layout stays consistent.
 //
 // What this component does NOT do:
 //   - It does not load data. The parent server component fetches
 //     rules + categories and passes them in.
-//   - It does not open the occurrence detail popover — that's P3-C7.
-//     Clicking a day calls `onSelectDay(iso)` so the parent can show
-//     a detail panel beside or below the calendar.
-//   - It does not include status/endedAt logic. `computeOccurrences`
-//     already returns `[]` for paused rules and respects ended/endDate.
+//   - It does not open the existing edit dialog itself — clicking a
+//     banner calls `onOpenRule(ruleId)` and the parent decides what
+//     to do. The parent already wires the same callback for the
+//     DayDetailPopover's "查看" button, so the two entry points share
+//     a single edit-flow implementation.
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
@@ -36,6 +39,7 @@ import {
   parseIso,
   toDayNumber,
 } from "@/lib/recurring-expense/occurrences";
+import { formatAmountCompact } from "@/lib/recurring-expense/format";
 import type { RecurrenceRule } from "@/lib/recurring-expense/rule-types";
 
 export interface PlanCalendarCategory {
@@ -51,7 +55,7 @@ export interface PlanCalendarProps {
    *  component only renders the month it was given. */
   viewMonth: string;
   rules: RecurrenceRule[];
-  /** Categories keyed by id — used to colour dots. Rules whose
+  /** Categories keyed by id — used to colour banners. Rules whose
    *  category is not in this map render with the fallback colour. */
   categoryMap: Map<string, PlanCalendarCategory>;
   /** Today's ISO date for "today" highlight. Tests pin this to a
@@ -60,15 +64,19 @@ export interface PlanCalendarProps {
   /** Currently selected day (highlighted with a ring). Optional. */
   selectedDay?: string | null;
   onSelectDay?: (iso: string) => void;
+  /** Fires when the user clicks a single banner — typically opens
+   *  the rule's edit dialog. Day-level clicks still go through
+   *  onSelectDay (which opens the day detail popover). */
+  onOpenRule?: (ruleId: string) => void;
   className?: string;
 }
 
 const WEEKDAY_HEADERS = ["日", "一", "二", "三", "四", "五", "六"] as const;
 const FALLBACK_COLOR = "hsl(var(--muted-foreground))";
-const MAX_DOTS = 3;
+const MAX_BANNERS = 3;
 
 /** Coerce a token to a CSS color. Unknown tokens fall back so the
- *  layout never shows a broken/black dot if a rule was created with
+ *  layout never shows a broken/black colour if a rule was created with
  *  a stale color value (or no category at all). */
 function tokenColor(token: string | undefined): string {
   if (!token) return FALLBACK_COLOR;
@@ -134,6 +142,7 @@ export function PlanCalendar({
   todayIso,
   selectedDay,
   onSelectDay,
+  onOpenRule,
   className,
 }: PlanCalendarProps): React.ReactElement {
   const cells = React.useMemo(() => buildMonthGrid(viewMonth), [viewMonth]);
@@ -181,74 +190,126 @@ export function PlanCalendar({
         ))}
       </div>
 
-      {/* 6 × 7 grid — fixed cell heights keep layout stable across months */}
+      {/* 6 × 7 grid — banners auto-expand each cell vertically; min-height
+          keeps empty months looking balanced. */}
       <div role="grid" aria-label={monthHeading} className="grid grid-cols-7">
         {cells.map((cell) => {
           const occs = occurrenceMap.get(cell.iso) ?? [];
           const isToday = todayIso != null && cell.iso === todayIso;
           const isSelected = selectedDay != null && cell.iso === selectedDay;
-          const visibleDots = occs.slice(0, MAX_DOTS);
-          const overflow = Math.max(0, occs.length - MAX_DOTS);
+          const visibleBanners = occs.slice(0, MAX_BANNERS);
+          const overflow = Math.max(0, occs.length - MAX_BANNERS);
 
           return (
-            <button
+            <div
               key={cell.iso}
-              type="button"
               role="gridcell"
+              tabIndex={0}
               data-iso={cell.iso}
               data-in-month={cell.inMonth ? "true" : "false"}
               aria-label={`${cell.iso}${occs.length > 0 ? ` ${occs.length} 项` : ""}`}
               aria-current={isToday ? "date" : undefined}
               aria-selected={isSelected || undefined}
               onClick={() => onSelectDay?.(cell.iso)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onSelectDay?.(cell.iso);
+                }
+              }}
               className={cn(
-                "relative flex h-20 flex-col items-start gap-1 border-b border-r border-border p-1.5 text-left outline-none transition-colors",
+                "relative flex min-h-[7rem] cursor-pointer flex-col gap-1 border-b border-r border-border p-1.5 text-left outline-none transition-colors",
                 "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring",
                 cell.inMonth
-                  ? "bg-background hover:bg-accent/40"
+                  ? "bg-background hover:bg-accent/30"
                   : "bg-muted/30 text-muted-foreground hover:bg-muted/50",
                 isSelected && "ring-2 ring-foreground ring-inset",
               )}
             >
+              {/* Day-number chip — purely decorative; the entire cell is
+                  already the "open day detail" target. */}
               <span
                 className={cn(
-                  "inline-flex size-6 items-center justify-center rounded-full text-xs font-medium",
+                  "inline-flex w-fit items-center gap-1 rounded-full px-1.5 text-xs font-medium",
                   isToday && "bg-primary text-primary-foreground",
                 )}
               >
                 {cell.day}
               </span>
 
-              {/* Dots row */}
-              {visibleDots.length > 0 ? (
-                <div className="mt-auto flex flex-wrap items-center gap-0.5">
-                  {visibleDots.map((rule, idx) => {
+              {/* Banner stack — every visible occurrence gets its own
+                  click target so the user can jump straight to edit
+                  without a popover hop. */}
+              {visibleBanners.length > 0 ? (
+                <div className="flex flex-col gap-0.5">
+                  {visibleBanners.map((rule, idx) => {
                     const cat = rule.categoryId
                       ? categoryMap.get(rule.categoryId)
                       : undefined;
-                    const color = tokenColor(cat?.colorToken);
+                    const colorToken = cat?.colorToken;
+                    const isPaletteToken =
+                      typeof colorToken === "string" &&
+                      CHART_TOKENS.includes(colorToken);
+                    const color = tokenColor(colorToken);
                     return (
-                      <span
+                      <button
                         key={`${rule.id}-${idx}`}
+                        type="button"
                         data-rule-id={rule.id}
-                        data-color={cat?.colorToken ?? "fallback"}
-                        aria-hidden="true"
-                        className="size-1.5 rounded-full"
-                        style={{ backgroundColor: color }}
-                      />
+                        data-color={isPaletteToken ? colorToken : "fallback"}
+                        data-testid={`banner-${cell.iso}-${rule.id}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (onOpenRule) onOpenRule(rule.id);
+                          else onSelectDay?.(cell.iso);
+                        }}
+                        title={`${rule.name} · ${formatAmountCompact(rule.amountCents)}`}
+                        aria-label={`${rule.name} ${formatAmountCompact(rule.amountCents)}`}
+                        style={{
+                          backgroundColor: color,
+                          // Keep the dot data-color contract for tests
+                          // even though we render a full banner now.
+                          borderLeftColor: color,
+                        }}
+                        className={cn(
+                          "flex w-full items-center justify-between gap-1 rounded-sm px-1.5 py-0.5",
+                          "text-[10px] font-medium text-white leading-tight",
+                          "outline-none ring-offset-background transition-opacity",
+                          "hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring",
+                          // Drop the bright tint for adjacent-month cells
+                          // so the in-month banners stay the focal point.
+                          !cell.inMonth && "opacity-60",
+                        )}
+                      >
+                        <span className="min-w-0 flex-1 truncate text-left">
+                          {rule.name}
+                        </span>
+                        <span className="shrink-0 tabular-nums">
+                          {formatAmountCompact(rule.amountCents)}
+                        </span>
+                      </button>
                     );
                   })}
                   {overflow > 0 ? (
-                    <span
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onSelectDay?.(cell.iso);
+                      }}
                       data-testid={`overflow-${cell.iso}`}
-                      className="ml-1 text-[10px] font-medium text-muted-foreground"
+                      className={cn(
+                        "rounded-sm px-1.5 py-0.5 text-left text-[10px] font-medium text-muted-foreground",
+                        "hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring outline-none",
+                      )}
+                      aria-label={`查看 ${cell.iso} 全部 ${occs.length} 项周期支出`}
                     >
                       +{overflow}
-                    </span>
+                    </button>
                   ) : null}
                 </div>
               ) : null}
-            </button>
+            </div>
           );
         })}
       </div>

--- a/src/components/plan/plan-calendar.tsx
+++ b/src/components/plan/plan-calendar.tsx
@@ -299,7 +299,7 @@ export function PlanCalendar({
                         <span className="min-w-0 flex-1 truncate text-left">
                           {rule.name}
                         </span>
-                        <span className="shrink-0 tabular-nums text-muted-foreground">
+                        <span className="shrink-0 tabular-nums text-foreground">
                           {formatAmountCompact(rule.amountCents)}
                         </span>
                       </button>

--- a/src/lib/recurring-expense/format.ts
+++ b/src/lib/recurring-expense/format.ts
@@ -58,6 +58,29 @@ export function formatAmountYuan(cents: number): string {
   return `¥${formatter.format(yuan)}`;
 }
 
+/** Compact yuan formatting for the calendar banner — keeps each cell
+ *  legible even when several rules pile up on one day. Uses Chinese
+ *  "万" past 10,000, falls back to full numbers below 1,000.
+ *
+ *  Examples:
+ *    9900     → "¥99"
+ *    250000   → "¥2,500"
+ *    1000000  → "¥1万"
+ *    1234500  → "¥1.2万"
+ *    100000000 → "¥1000万"
+ */
+export function formatAmountCompact(cents: number): string {
+  const yuan = Math.abs(cents) / 100;
+  const sign = cents < 0 ? "-" : "";
+  if (yuan >= 10000) {
+    const wan = yuan / 10000;
+    const text = wan >= 100 ? wan.toFixed(0) : wan.toFixed(1).replace(/\.0$/, "");
+    return `${sign}¥${text}万`;
+  }
+  const rounded = Math.round(yuan);
+  return `${sign}¥${new Intl.NumberFormat("zh-CN").format(rounded)}`;
+}
+
 /** Pure: derive the UI display status. `expired` is computed from
  *  endDate < today for active rules and never persisted. */
 export function deriveDisplayStatus(


### PR DESCRIPTION
## Summary

资金计划日历页面把每天的小圆点改造成更明显的彩色信息条 banner，每条显示规则名 + 紧凑金额，颜色用分类的 `chart-N` token。点击 banner 直接打开既有编辑弹窗；当日条目超过 3 条用 `+N` 折叠，点击或点单元格空白处仍弹出 `DayDetailPopover`。

视觉做了两轮 review 调整：banner 改成「彩色 3px 左条 + `bg-muted/70` 中性底 + `text-foreground` 文本」，所有颜色都走主题 token，light/dark 都满足 WCAG AA。键盘聚焦 banner 后按 Enter/Space 只触发编辑，不会同时打开 day-detail（通过 `e.target === e.currentTarget` 守卫）。

Closes STU-524.

## Changes

- `src/components/plan/plan-calendar.tsx` — dots → banners，cell 改为 `min-h-[7rem]` flex 列；新增 `onOpenRule` prop
- `src/app/plan/calendar/calendar-client.tsx` — wire `onOpenRule` 到 edit dialog（沿用既有 `RecurringExpenseForm`）
- `src/lib/recurring-expense/format.ts` — 新增 `formatAmountCompact`（≥10000 用「万」）
- 单测：plan-calendar 新增 banner 渲染 / 点击 / 键盘 / overflow 共 7 个用例；format 新增 `formatAmountCompact` 单测

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test`（957/957）
- [ ] 手动 `bun run dev` 在 `/plan/calendar` 验证 banner 颜色、点击编辑、+N 折叠（合并前由人验证）