### PR TITLE
chore(deps): bump better-sqlite3 12.10.0 → 12.10.1 (defer eslint v10)

### DIFF
--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -15,7 +15,7 @@
         "@cloudflare/workers-types": "^4.20260612.1",
         "@types/better-sqlite3": "^7.6.13",
         "@vitest/coverage-v8": "^4.1.8",
-        "better-sqlite3": "^12.10.0",
+        "better-sqlite3": "^12.10.1",
         "vitest": "^4.1.8",
         "wrangler": "^4.100.0",
       },
@@ -262,7 +262,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "better-sqlite3": ["better-sqlite3@12.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ=="],
+    "better-sqlite3": ["better-sqlite3@12.10.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-HfFtzCqnSfwB3+HroF6PSKzyh+7RfNMGPCzHFUZXRlvrPCb4P3cvxKZNN43Sr7IrkofqQZM+gIvffGpA8VvqgA=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -21,7 +21,7 @@
     "@cloudflare/workers-types": "^4.20260612.1",
     "@types/better-sqlite3": "^7.6.13",
     "@vitest/coverage-v8": "^4.1.8",
-    "better-sqlite3": "^12.10.0",
+    "better-sqlite3": "^12.10.1",
     "vitest": "^4.1.8",
     "wrangler": "^4.100.0"
   },


### PR DESCRIPTION
## Summary

Batch dependency upgrade pass for noheir.

| Package | From | To | Status |
|---------|------|-----|--------|
| `better-sqlite3` (worker devDep) | 12.10.0 | 12.10.1 | ✅ bumped |
| `eslint` (root devDep) | 9.39.4 | 10.5.0 | ⛔ deferred — see below |

### `better-sqlite3` (patch)
Pure patch release. `bun run test` in `worker/` passes all 247 tests against the upgraded native binding.

### `eslint` v9 → v10 — breaking change assessment

⚠️ **Cannot land this bump in the current dependency graph.** Local upgrade attempt produced:

```
TypeError: Error while loading rule 'react/display-name':
  contextOrFilename.getFilename is not a function
  at resolveBasedir (eslint-plugin-react/lib/util/version.js:31:100)
```

Root cause: ESLint 10 removed the legacy `context.getFilename()` / `getCwd()` / `getSourceCode()` shims (per the [v10 migration guide](https://eslint.org/docs/head/use/migrate-to-10.0.0)). `eslint-plugin-react@7.37.5` (the latest release, brought in transitively via `eslint-config-next@16.2.9`) still calls `context.getFilename()` directly.

Upstream tracking: [jsx-eslint/eslint-plugin-react#3977 — "ESLint v10 compatibility"](https://github.com/jsx-eslint/eslint-plugin-react/issues/3977), still open.

Other v10-impacting items reviewed but **not** blockers for this repo:
- Node engines: v10 requires Node ≥20.19 / ≥22.13 / ≥24 — our CI image and local toolchain are on Node 26.
- `typescript-eslint@8.58.x` already declares `eslint: ^8.57.0 || ^9.0.0 || ^10.0.0`.
- `eslint-config-next@16.2.9` peer is `eslint >= 9.0.0` — also compatible.
- New recommended rules (`no-unassigned-vars`, `no-useless-assignment`, `preserve-caught-error`) and `no-shadow-restricted-names` reporting `globalThis` would surface only after upgrading; not evaluated here.

**Recommendation:** keep #83 open and re-attempt once `eslint-plugin-react` ships v10 support (or `eslint-config-next` swaps to a v10-ready plugin set). Choko will refresh the target version on its next scan automatically.

## Test plan

- [x] `cd worker && bun run test` — 247 / 247 passed
- [x] `bun run test` (root) — 966 / 966 passed
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (still on eslint 9)

Closes nocoo/noheir#88