### PR TITLE
chore(deps): bump @cloudflare/workers-types 4.20260616.1 → 4.20260617.1

### DIFF
--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -12,7 +12,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260615.1",
+        "@cloudflare/workers-types": "4.20260617.1",
         "@types/better-sqlite3": "^7.6.13",
         "@vitest/coverage-v8": "^4.1.9",
         "better-sqlite3": "^12.11.1",
@@ -56,7 +56,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260616.1", "", { "os": "win32", "cpu": "x64" }, "sha512-RaDVF9bSbPiPTq6vHYrgnv1TcQEcYnOr0WB3hWJ4yg2fBfpi2ygU6cYPuFeDwyFE9aPW5S6FBAkNmpKYueK4DQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260616.1", "", {}, "sha512-AHyA0NC2/gNOHiMN6vzS25xenMaQ0XTzfw+MUQSQHXQDjLldxCBwjjtbNfKhBg540qGXIEx31kM1+L84GyECJw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260617.1", "", {}, "sha512-HdbP3CNcdMZBwegitFDjWvzv+6wPkFXvV9gBXMnf6RjV2Cy3W8TJL3IhSEGul0S6F1DHjnucP7lrpIsvkzNEjA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -18,7 +18,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260615.1",
+    "@cloudflare/workers-types": "4.20260617.1",
     "@types/better-sqlite3": "^7.6.13",
     "@vitest/coverage-v8": "^4.1.9",
     "better-sqlite3": "^12.11.1",


### PR DESCRIPTION
## Summary

Patch-level bump of `@cloudflare/workers-types` (worker workspace devDependency) from `4.20260616.1` to `4.20260617.1`.

## Verification

- Worker `tsc --noEmit` passes
- Worker tests: 16 files, 247 tests passing

Closes #103