### PR TITLE
chore(deps): bump @cloudflare/workers-types 4.20260620.1 → 4.20260621.1 in worker

### DIFF
--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -12,7 +12,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260620.1",
+        "@cloudflare/workers-types": "4.20260621.1",
         "@types/better-sqlite3": "^7.6.13",
         "@vitest/coverage-v8": "^4.1.9",
         "better-sqlite3": "^12.11.1",
@@ -57,7 +57,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260617.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260620.1", "", {}, "sha512-WB81w9u1bAS7KcekpC7/nYhLpIXAEtgybso7XgGJV8CQKNkNPYcyjvICLdghOlDBi/9Ivk+f7NRckV2Bkq1bDg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260621.1", "", {}, "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -18,7 +18,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260620.1",
+    "@cloudflare/workers-types": "4.20260621.1",
     "@types/better-sqlite3": "^7.6.13",
     "@vitest/coverage-v8": "^4.1.9",
     "better-sqlite3": "^12.11.1",


### PR DESCRIPTION
## Summary

- Bumps `@cloudflare/workers-types` in `worker/` from `4.20260620.1` to `4.20260621.1` (minor).

Closes nocoo/noheir#117

### `eslint 9.39.4 → 10.5.0` (#83) — held, not closed

ESLint 10 dropped the legacy `context.getFilename()` API. The transitive `eslint-plugin-react@7.37.5` brought in by `eslint-config-next@16.2.9` still calls that API, and no ESLint-10-compatible release of the plugin has shipped yet (latest 7.37.5 dates back to 2025-04-03, peer `eslint: ... ^9.7`). Reproduced the failure locally and rolled back — same blocker SDE-03 already documented on #83. Leaving #83 open so the next autopilot scan picks it up once upstream catches up.

## Verification

- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run test` ✅ (966 tests)
- `bun run test:worker` ✅ (247 tests)
