### PR TITLE
security(install): harden bun install against supply-chain script injection

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,8 +1,26 @@
 [install]
-# Skip lifecycle scripts (preinstall/install/postinstall/prepare) for all dependencies,
-# including packages in `trustedDependencies`. Hardens the install against
-# supply-chain attacks that piggy-back on node-gyp / postinstall hooks
-# (e.g. Snyk 2026-06 native-binding model). Native packages we use ship
-# prebuilt binaries; if a prebuilt is unavailable, run a one-off
-# `bun install --trusted=<pkg>` (see README).
+# Defense-in-depth supply-chain hardening (Snyk 2026-06 node-gyp model):
+# block ALL dependency lifecycle scripts (preinstall/install/postinstall/prepare),
+# including for packages in package.json#trustedDependencies.
+#
+# Why this is safe for the root project:
+#   None of the current root native deps (esbuild, sharp, @tailwindcss/oxide,
+#   next, unrs-resolver) need install scripts to function — they ship
+#   per-platform `optionalDependencies` packages or no-op install scripts.
+#
+# If a future native dep DOES require its install script (e.g. node-gyp
+# rebuild, prebuild-install download), do NOT just delete this file.
+# Either:
+#   1. Move that dep's install logic to a per-platform optional package, or
+#   2. Promote the workdir to a sub-package with its own package.json +
+#      explicit `trustedDependencies` allowlist, matching `worker/`.
+#
+# Recovery (only if you must temporarily run a blocked script): `cd` into
+# the package dir, then `bun pm trust <pkg>` — note this WRITES to
+# package.json#trustedDependencies and executes the package's scripts.
+# See docs/04-run.md for the canonical procedure.
+#
+# This config does NOT propagate into subdirectories. `worker/` runs
+# `bun install` with cwd inside worker/, which never reads this file;
+# worker hardens via package.json#trustedDependencies allowlist instead.
 ignoreScripts = true

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,8 @@
+[install]
+# Skip lifecycle scripts (preinstall/install/postinstall/prepare) for all dependencies,
+# including packages in `trustedDependencies`. Hardens the install against
+# supply-chain attacks that piggy-back on node-gyp / postinstall hooks
+# (e.g. Snyk 2026-06 native-binding model). Native packages we use ship
+# prebuilt binaries; if a prebuilt is unavailable, run a one-off
+# `bun install --trusted=<pkg>` (see README).
+ignoreScripts = true

--- a/docs/04-run.md
+++ b/docs/04-run.md
@@ -9,18 +9,48 @@
 ## 安装依赖
 
 ```bash
-bun install
+bun install                  # 根目录
+cd worker && bun install     # worker 子包独立安装
 ```
 
-> 仓库根 `bunfig.toml` 设置 `[install] ignoreScripts = true`，禁用所有依赖的 `preinstall`/`install`/`postinstall`/`prepare` 生命周期脚本（含 `trustedDependencies` 列表中的包），用于防御 node-gyp 风格供应链投毒。当前依赖（`better-sqlite3`、`sharp`、`@tailwindcss/oxide`、`next` 等）均通过 prebuilt binary 安装，不依赖 install 脚本。
+> 仓库使用 **两层供应链硬约束**，防御 node-gyp 风格的 install-hook 投毒（Snyk 2026-06）：
 >
-> 若将来某个 native binding 的 prebuilt 不可用、必须本地编译，临时跑：
+> | 层 | 位置 | 机制 | 当前白名单 |
+> |----|------|------|-----------|
+> | 根 | `bunfig.toml` | `[install] ignoreScripts = true` —— 阻断**全部**依赖的 install/postinstall/prepare 等脚本（含 trustedDependencies 中列出的包）。这是 deny-all 防御。 | （无脚本可跑） |
+> | worker | `worker/package.json#trustedDependencies` | 显式 allowlist。Bun 默认会信任内置 367 包白名单；定义该字段后**替换**默认列表，只放行其中包的脚本。 | `better-sqlite3`、`esbuild`、`workerd` |
+>
+> **为什么 worker 不能用 `ignoreScripts`？** `worker/` 用 `better-sqlite3` 跑单元测试，它的 `install` 钩子（`prebuild-install`）必须运行才能下载 `.node` prebuilt binary，否则测试无法 require。所以 worker 不能简单 deny-all，需要走显式 allowlist。
+>
+> **bunfig 不跨目录继承**：`cd worker && bun install` 不会读取根 `bunfig.toml`。这是 Bun 1.3.x 的行为，**不要**靠根 bunfig 间接约束 worker。
+>
+> ### 校验配置生效
 >
 > ```bash
-> bun install --trusted=better-sqlite3   # 例：仅放行该包
+> # 在根 / worker 各自跑一次：
+> bun pm untrusted          # 看被阻断的包；root 应当为空（无 trusted 脚本本来就少），worker 应列出 sharp 等非白名单 native dep
+> bun install --verbose 2>&1 | rg -i "lifecycle scripts|starting scripts"
+> #   root：应看到 [Lifecycle Scripts] ignoring … 但**没有** [Scripts] Starting scripts
+> #   worker：应只看到 [Scripts] Starting scripts for "better-sqlite3" / "workerd"
 > ```
 >
-> 不要直接修改 `bunfig.toml` 关掉硬约束。
+> ### 临时放行脚本（不建议长期使用）
+>
+> 若某个被阻断的包确实需要本地编译/下载产物，**先 `cd` 到该包所在 package（根或 worker），然后**：
+>
+> ```bash
+> bun pm untrusted          # 确认是哪个包
+> bun pm trust <pkg>        # 执行该包的脚本，并把它写入当前 package.json#trustedDependencies
+> ```
+>
+> ⚠️ `bun pm trust <pkg>` 有持久副作用：
+>
+> 1. 直接修改 `package.json` 的 `trustedDependencies` 字段（worker 会真的扩允许列表）；
+> 2. 同步执行该包的 install/postinstall。
+>
+> 对 root 而言，因为 `bunfig.toml ignoreScripts=true` 会**覆盖** trustedDependencies，加进 root 的 `package.json#trustedDependencies` 也不会让脚本跑——只能临时把 `ignoreScripts` 注释掉或挪到 worker 模式。请在 PR 描述里写明动机。
+>
+> （历史误区：早期文档曾写 `bun install --trusted=<pkg>`，Bun 1.3.14 没有这个 flag，会被默默忽略。正确命令是 `bun pm trust`。）
 
 ## 环境变量
 

--- a/docs/04-run.md
+++ b/docs/04-run.md
@@ -12,6 +12,16 @@
 bun install
 ```
 
+> 仓库根 `bunfig.toml` 设置 `[install] ignoreScripts = true`，禁用所有依赖的 `preinstall`/`install`/`postinstall`/`prepare` 生命周期脚本（含 `trustedDependencies` 列表中的包），用于防御 node-gyp 风格供应链投毒。当前依赖（`better-sqlite3`、`sharp`、`@tailwindcss/oxide`、`next` 等）均通过 prebuilt binary 安装，不依赖 install 脚本。
+>
+> 若将来某个 native binding 的 prebuilt 不可用、必须本地编译，临时跑：
+>
+> ```bash
+> bun install --trusted=better-sqlite3   # 例：仅放行该包
+> ```
+>
+> 不要直接修改 `bunfig.toml` 关掉硬约束。
+
 ## 环境变量
 
 ```bash

--- a/docs/04-run.md
+++ b/docs/04-run.md
@@ -40,15 +40,18 @@ cd worker && bun install     # worker 子包独立安装
 >
 > ```bash
 > bun pm untrusted          # 确认是哪个包
-> bun pm trust <pkg>        # 执行该包的脚本，并把它写入当前 package.json#trustedDependencies
+> bun pm trust <pkg>        # 一次性执行该包的脚本，并把它写入当前 package.json#trustedDependencies
 > ```
 >
-> ⚠️ `bun pm trust <pkg>` 有持久副作用：
+> `bun pm trust` 在两层硬约束下的精确语义（已实测 Bun 1.3.14）：
 >
-> 1. 直接修改 `package.json` 的 `trustedDependencies` 字段（worker 会真的扩允许列表）；
-> 2. 同步执行该包的 install/postinstall。
+> | 行为 | root（受 `bunfig ignoreScripts=true` 约束） | worker（仅靠 trustedDependencies allowlist） |
+> |------|---------------------------------------------|----------------------------------------------|
+> | 立即执行该包脚本 | ✅ 会跑一次 | ✅ 会跑一次 |
+> | 写入 `package.json#trustedDependencies` | ✅ 会写入 | ✅ 会写入 |
+> | 下一次普通 `bun install` 再次跑该脚本 | ❌ **不会**——bunfig 仍 deny-all | ✅ 会跑（trustedDeps 接管） |
 >
-> 对 root 而言，因为 `bunfig.toml ignoreScripts=true` 会**覆盖** trustedDependencies，加进 root 的 `package.json#trustedDependencies` 也不会让脚本跑——只能临时把 `ignoreScripts` 注释掉或挪到 worker 模式。请在 PR 描述里写明动机。
+> 因此 root 的语义是：**`bun pm trust <pkg>` 一次性救火可用**（直接产出 `.node` binary / 解压产物等），但下次 reinstall 后产物消失。如果某个 root 依赖每次 install 都必须跑脚本才能工作，最终只有两条路：(a) 把它迁出根，落到一个独立 sub-package（如 `worker/`），用 trustedDependencies allowlist 长期放行；或 (b) 在该次维护窗口里临时把根 `bunfig.toml` 的 `ignoreScripts` 注释掉，跑完 install 后立刻还原。两种动作都需要在 PR 描述里说清动机。
 >
 > （历史误区：早期文档曾写 `bun install --trusted=<pkg>`，Bun 1.3.14 没有这个 flag，会被默默忽略。正确命令是 `bun pm trust`。）
 

--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -21,6 +21,11 @@
       },
     },
   },
+  "trustedDependencies": [
+    "better-sqlite3",
+    "esbuild",
+    "workerd",
+  ],
   "overrides": {
     "@hono/node-server": "1.19.13",
     "esbuild": "^0.28.1",

--- a/worker/package.json
+++ b/worker/package.json
@@ -35,5 +35,10 @@
     "undici": "7.28.0",
     "vite": "8.0.16",
     "ws": "8.21.0"
-  }
+  },
+  "trustedDependencies": [
+    "better-sqlite3",
+    "esbuild",
+    "workerd"
+  ]
 }


### PR DESCRIPTION
## Summary

- 新增根 `bunfig.toml [install] ignoreScripts = true`，对所有依赖的 install/postinstall/prepare 脚本做 deny-all（含 `trustedDependencies` 列表内的包），防御 node-gyp 风格供应链投毒（Snyk 2026-06）。
- `worker/` 子包独立于根 `bunfig`，改用显式 `package.json#trustedDependencies` allowlist（`better-sqlite3`、`esbuild`、`workerd`）——因为 `worker/tests/setup.ts` 需要 `better-sqlite3` 的 `prebuild-install` 钩子下载 `.node` binary，无法 deny-all。显式数组替换 Bun 内置 367 包默认信任列表，实测 transitive 的 `sharp` 现被阻断。
- `docs/04-run.md` 双层硬约束架构 + `bun pm trust` 在两种语境下"一次性执行 vs. 持续放行"的精确语义表。

## Verification (Bun 1.3.14, clean install)

| 命令 | 结果 |
|------|------|
| `rm -rf node_modules worker/node_modules && bun install`（根） | ✅ 791 packages |
| `cd worker && bun install` | ✅ 226 packages |
| `bun pm untrusted`（根） | ✅ `Found 0 untrusted dependencies with scripts` |
| `bun pm untrusted`（worker） | ✅ 列出 `sharp@0.34.5` 被阻断（证明 allowlist 生效） |
| `bun install --verbose`（根） | ✅ 仅 `[Lifecycle Scripts] ignoring …`，无 `[Scripts] Starting scripts` |
| `bun install --verbose`（worker） | ✅ 仅 `[Scripts] Starting scripts for "better-sqlite3"/"workerd"` |
| `node -e "require('better-sqlite3')"`（worker） | ✅ binding 加载，`SELECT 1` 返回 `{ v: 1 }` |
| `bun run test`（根） | ✅ 72 files / 966 / 966 passed |
| `bun run test:worker` | ✅ 16 files / 247 / 247 passed |
| `bun run typecheck`（根 + worker） | ✅ 均 clean |

## Test plan

- [ ] CI green
- [ ] 本地 clean reinstall（根 + worker）成功
- [ ] worker 单元测试 247 / 247 通过
- [ ] 根单元测试 966 / 966 通过
- [ ] `bun pm untrusted` 在 worker 报告非白名单 native dep 被阻断
