### PR TITLE
chore(deps): bump @cloudflare/workers-types 5.20260712.1 → 5.20260713.1

### DIFF
--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -11,7 +11,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.3",
-        "@cloudflare/workers-types": "5.20260712.1",
+        "@cloudflare/workers-types": "5.20260713.1",
         "@types/better-sqlite3": "^7.6.13",
         "@vitest/coverage-v8": "4.1.10",
         "better-sqlite3": "^12.11.1",
@@ -80,7 +80,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260708.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260712.1", "", {}, "sha512-tkQ18Lz41EPXLzh4cSuIGQzztDVueuGfTcjlP4M7Qa0rfHpVBNItf3GRkd9O0JgiXs9csAwz/kVv7sjYXSoF2w=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260713.1", "", {}, "sha512-4YZE9YIzr3iP9eRUV4ekZozLLsYQFFKxmMJfAcsteCuzKJ7RJrLqcCxm1aMzTE9uFcy+D6A89WE+cjJadF2c9g=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.3",
-    "@cloudflare/workers-types": "5.20260712.1",
+    "@cloudflare/workers-types": "5.20260713.1",
     "@types/better-sqlite3": "^7.6.13",
     "@vitest/coverage-v8": "4.1.10",
     "better-sqlite3": "^12.11.1",


### PR DESCRIPTION
## Summary

Bump `@cloudflare/workers-types` from `5.20260712.1` → `5.20260713.1` (minor) in `worker/` devDependencies.

Closes #213.

## Verification

- `bun install` (in `worker/`) — lockfile regenerated
- `bun run worker:typecheck` — clean
- `bun run test:worker` — 247 tests passed
